### PR TITLE
Remove traditional analysis mode

### DIFF
--- a/interrupt_analyzer.cpp
+++ b/interrupt_analyzer.cpp
@@ -25,48 +25,7 @@ InterruptAnalyzer::~InterruptAnalyzer() {
     cleanupStreamingComponents();
 }
 
-Json::Value InterruptAnalyzer::analyzeHandler(const std::string& handler_name, const std::string& handler_file) {
-    // 保持原有接口的兼容性
-    std::cout << "\n🎯 开始分析中断处理函数: " << handler_name << " (兼容模式)" << std::endl;
-    
-    auto start_time = std::chrono::high_resolution_clock::now();
-
-    if (!loadAndAnalyzeProject()) {
-        Json::Value error_result;
-        error_result["error"] = "Failed to load and analyze project";
-        return error_result;
-    }
-
-    Json::Value result;
-    result["handler_name"] = handler_name;
-    result["handler_file"] = handler_file;
-
-    auto func_it = data.function_locations.find(handler_name);
-    if (func_it == data.function_locations.end()) {
-        result["error"] = "Handler function not found";
-        return result;
-    }
-
-    std::unordered_set<std::string> reachable;
-    std::unordered_set<std::string> indirect_calls;
-    std::tie(reachable, indirect_calls) = buildReachableFunctions(handler_name);
-
-    std::cout << "✅ 找到 " << reachable.size() << " 个可达函数";
-    if (!indirect_calls.empty()) {
-        std::cout << "，其中 " << indirect_calls.size() << " 个通过函数指针调用";
-    }
-    std::cout << std::endl;
-
-    result = generateAnalysisResult(handler_name, handler_file, reachable, indirect_calls);
-
-    auto end_time = std::chrono::high_resolution_clock::now();
-    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
-    printAnalysisStatistics(duration.count());
-
-    return result;
-}
-
-Json::Value InterruptAnalyzer::analyzeHandlerStreaming(const std::string& handler_name, 
+Json::Value InterruptAnalyzer::analyzeHandlerStreaming(const std::string& handler_name,
                                                      const std::string& handler_file) {
     std::cout << "\n🚀 开始流式分析中断处理函数: " << handler_name << std::endl;
     
@@ -122,35 +81,6 @@ Json::Value InterruptAnalyzer::analyzeHandlerStreaming(const std::string& handle
 void InterruptAnalyzer::updateConfig(const StreamingConfig& new_config) {
     config = new_config;
     std::cout << "📝 流式处理配置已更新" << std::endl;
-}
-
-bool InterruptAnalyzer::loadAndAnalyzeProject() {
-    // 原有的分析方法 - 保持兼容性
-    if (cache_manager->cacheExists()) {
-        std::cout << "📦 发现分析缓存，正在加载..." << std::endl;
-        if (cache_manager->loadFromCache()) {
-            std::cout << "✅ 缓存加载成功" << std::endl;
-            return true;
-        } else {
-            std::cout << "⚠️ 缓存加载失败，重新分析..." << std::endl;
-        }
-    }
-
-    std::cout << "📁 开始分析项目源文件..." << std::endl;
-    std::cout << "🔄 使用传统批处理分析..." << std::endl;
-
-    bool success = frontend_manager->runAnalysis();
-    
-    if (success) {
-        std::cout << "💾 保存分析结果到缓存..." << std::endl;
-        if (cache_manager->saveToCache()) {
-            std::cout << "✅ 缓存保存成功" << std::endl;
-        } else {
-            std::cout << "⚠️ 缓存保存失败" << std::endl;
-        }
-    }
-
-    return success;
 }
 
 bool InterruptAnalyzer::loadAndAnalyzeProjectStreaming() {

--- a/interrupt_analyzer.h
+++ b/interrupt_analyzer.h
@@ -60,12 +60,7 @@ public:
     ~InterruptAnalyzer();
 
     /**
-     * 原有接口 - 保持兼容性
-     */
-    Json::Value analyzeHandler(const std::string& handler_name, const std::string& handler_file);
-
-    /**
-     * 新的流式分析接口
+     * 流式分析接口
      */
     Json::Value analyzeHandlerStreaming(const std::string& handler_name, const std::string& handler_file);
 
@@ -97,10 +92,6 @@ public:
     AnalysisStats getStatistics() const;
 
 private:
-    /**
-     * 原有方法 - 保持不变
-     */
-    bool loadAndAnalyzeProject();
     std::pair<std::unordered_set<std::string>, std::unordered_set<std::string>>
     buildReachableFunctions(const std::string& handler_name);
     Json::Value generateAnalysisResult(const std::string& handler_name,

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,6 @@
 /**
  * C++ 中断处理函数分析器 - 主程序 (流式处理优化版)
- * 支持传统模式和流式处理模式
+ * 仅支持流式处理模式
  */
 
 #include "interrupt_analyzer.h"
@@ -37,12 +37,6 @@ static cl::opt<std::string> HandlerFile("file",
 static cl::opt<std::string> OutputFile("output",
     cl::desc("Output JSON file"),
     cl::init("analysis_result.json"),
-    cl::cat(AnalyzerCategory));
-
-// 流式处理选项
-static cl::opt<bool> EnableStreaming("streaming",
-    cl::desc("Enable streaming processing mode"),
-    cl::init(true),
     cl::cat(AnalyzerCategory));
 
 static cl::opt<unsigned> MaxWorkerThreads("worker-threads",
@@ -90,15 +84,7 @@ static cl::extrahelp MoreHelp(
     "  ✅ 实时进度报告\n"
     "  ✅ 内存压力管理\n\n"
     "使用示例:\n"
-    "  # 流式处理模式（推荐）\n"
-    "  ./interrupt_analyzer --handler=timer_irq --file=timer.c \\\n"
-    "    --streaming --worker-threads=8 --max-memory=1024 \\\n"
-    "    -p build src/timer.c\n\n"
-    "  # 传统模式（兼容性）\n"
-    "  ./interrupt_analyzer --handler=vm_interrupt \\\n"
-    "    --file=drivers/virtio/virtio_mmio.c \\\n"
-    "    --no-streaming \\\n"
-    "    -p ../kafl.linux ../kafl.linux/drivers/virtio/virtio_mmio.c\n\n"
+    "  ./interrupt_analyzer --handler=timer_irq --file=timer.c -p build src/timer.c\n\n",
     "性能调优选项:\n"
     "  --worker-threads=N 工作线程数（默认: CPU核心数）\n"
     "  --max-memory=N     最大内存使用量MB（默认: 500）\n"
@@ -132,24 +118,21 @@ StreamingConfig createStreamingConfig() {
 /**
  * 显示配置信息
  */
-void displayConfiguration(const StreamingConfig& config, bool streaming_mode) {
+void displayConfiguration(const StreamingConfig& config) {
     std::cout << "⚙️  分析配置:" << std::endl;
-    std::cout << "   处理模式: " << (streaming_mode ? "流式处理" : "传统批处理") << std::endl;
-    
-    if (streaming_mode) {
-        std::cout << "   工作线程: " << config.max_worker_threads << std::endl;
-        std::cout << "   内存限制: " << config.max_memory_mb << " MB" << std::endl;
-        std::cout << "   批处理大小: " << config.batch_size << std::endl;
-        std::cout << "   增量分析: " << (config.enable_incremental ? "启用" : "禁用") << std::endl;
-        std::cout << "   内存管理: " << (config.enable_memory_pressure_relief ? "启用" : "禁用") << std::endl;
-        std::cout << "   缓存目录: " << config.cache_directory << std::endl;
-    }
+    std::cout << "   处理模式: 流式处理" << std::endl;
+    std::cout << "   工作线程: " << config.max_worker_threads << std::endl;
+    std::cout << "   内存限制: " << config.max_memory_mb << " MB" << std::endl;
+    std::cout << "   批处理大小: " << config.batch_size << std::endl;
+    std::cout << "   增量分析: " << (config.enable_incremental ? "启用" : "禁用") << std::endl;
+    std::cout << "   内存管理: " << (config.enable_memory_pressure_relief ? "启用" : "禁用") << std::endl;
+    std::cout << "   缓存目录: " << config.cache_directory << std::endl;
 }
 
 /**
  * 显示结果摘要
  */
-void displayResultSummary(const Json::Value& result, bool streaming_mode) {
+void displayResultSummary(const Json::Value& result) {
     std::cout << "\n📊 分析结果摘要:" << std::endl;
     std::cout << "   可达函数: " << result["statistics"]["reachable_functions"].asInt() << std::endl;
 
@@ -160,17 +143,16 @@ void displayResultSummary(const Json::Value& result, bool streaming_mode) {
     std::cout << "   全局变量写操作: " << result["statistics"]["total_writes"].asInt() << std::endl;
     std::cout << "   寄存器操作: " << result["statistics"]["register_operations"].asInt() << std::endl;
 
-    // 流式处理特有统计
-    if (streaming_mode && result.isMember("streaming_stats")) {
+    if (result.isMember("streaming_stats")) {
         std::cout << "\n🚀 流式处理统计:" << std::endl;
         std::cout << "   总文件数: " << result["streaming_stats"]["total_files"].asInt() << std::endl;
         std::cout << "   缓存命中率: " << result["streaming_stats"]["cache_hit_rate"].asInt() << "%" << std::endl;
-        
+
         if (result["streaming_stats"]["throughput"].asDouble() > 0) {
-            std::cout << "   处理吞吐: " << std::fixed << std::setprecision(1) 
+            std::cout << "   处理吞吐: " << std::fixed << std::setprecision(1)
                       << result["streaming_stats"]["throughput"].asDouble() << " 文件/秒" << std::endl;
         }
-        
+
         std::cout << "   内存使用: " << result["streaming_stats"]["memory_usage_mb"].asInt() << " MB" << std::endl;
     }
 
@@ -232,14 +214,11 @@ bool saveResults(const Json::Value& result, const std::string& filename) {
 /**
  * 根据 handler 名生成输出文件名
  */
-std::string getOutputFileWithHandler(const std::string& base, const std::string& handler, bool streaming) {
+std::string getOutputFileWithHandler(const std::string& base, const std::string& handler) {
     std::string filename = base;
     auto pos = filename.rfind('.');
-    std::string suffix = "_" + handler;
-    if (streaming) {
-        suffix += "_streaming";
-    }
-    
+    std::string suffix = "_" + handler + "_streaming";
+
     if (pos != std::string::npos) {
         filename.insert(pos, suffix);
     } else {
@@ -329,10 +308,9 @@ int main(int argc, const char** argv) {
 
     // 创建配置
     StreamingConfig config = createStreamingConfig();
-    bool streaming_mode = EnableStreaming.getValue();
-    
+
     // 生成输出文件名
-    std::string final_output = getOutputFileWithHandler(OutputFile, HandlerName, streaming_mode);
+    std::string final_output = getOutputFileWithHandler(OutputFile, HandlerName);
 
     // 显示欢迎信息
     std::cout << "===============================================" << std::endl;
@@ -345,22 +323,16 @@ int main(int argc, const char** argv) {
     std::cout << "📁 源文件数量: " << options_parser.getSourcePathList().size() << std::endl;
     std::cout << "===============================================" << std::endl;
     
-    displayConfiguration(config, streaming_mode);
+    displayConfiguration(config);
 
     // 创建分析器
     InterruptAnalyzer analyzer(compile_commands_path, config);
-    
+
     Json::Value result;
     auto start_time = std::chrono::high_resolution_clock::now();
-    
-    // 根据模式选择分析方法
-    if (streaming_mode) {
-        std::cout << "\n🚀 启动流式处理模式..." << std::endl;
-        result = analyzer.analyzeHandlerStreaming(HandlerName, HandlerFile);
-    } else {
-        std::cout << "\n🔄 启动传统分析模式..." << std::endl;
-        result = analyzer.analyzeHandler(HandlerName, HandlerFile);
-    }
+
+    std::cout << "\n🚀 启动流式处理模式..." << std::endl;
+    result = analyzer.analyzeHandlerStreaming(HandlerName, HandlerFile);
     
     auto end_time = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
@@ -374,7 +346,7 @@ int main(int argc, const char** argv) {
     // 添加性能指标到结果中
     result["performance_metrics"] = Json::Value();
     result["performance_metrics"]["total_time_ms"] = static_cast<int>(duration.count());
-    result["performance_metrics"]["processing_mode"] = streaming_mode ? "streaming" : "traditional";
+    result["performance_metrics"]["processing_mode"] = "streaming";
     
     // 保存结果
     if (saveResults(result, final_output)) {
@@ -384,22 +356,13 @@ int main(int argc, const char** argv) {
     }
 
     // 显示结果摘要
-    displayResultSummary(result, streaming_mode);
-    
-    // 显示性能建议
-    if (streaming_mode) {
-        displayPerformanceAdvice(result, config);
-    }
+    displayResultSummary(result);
 
-    std::cout << "\n🎉 " << (streaming_mode ? "流式" : "传统") << "分析完成！" 
-              << "总耗时: " << duration.count() << " ms" << std::endl;
-    
-    if (streaming_mode) {
-        std::cout << "💡 提示: 流式处理模式已优化内存使用和处理速度" << std::endl;
-        std::cout << "💡 提示: 使用 --no-streaming 可切换到传统模式进行对比" << std::endl;
-    } else {
-        std::cout << "💡 提示: 使用 --streaming 启用流式处理模式获得更好性能" << std::endl;
-    }
+    // 显示性能建议
+    displayPerformanceAdvice(result, config);
+
+    std::cout << "\n🎉 流式分析完成！" << "总耗时: " << duration.count() << " ms" << std::endl;
+    std::cout << "💡 提示: 流式处理模式已优化内存使用和处理速度" << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- Drop legacy non-streaming analysis interface and rely solely on streaming mode
- Simplify configuration and result handling for the streaming analyzer
- Update command-line help to reflect streaming-only usage

## Testing
- `make` *(fails: clang++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ff5cd190832ba684a5a0eca7a89b